### PR TITLE
explicitly use the silent xml in the install cmd.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,7 +63,7 @@ end
 
 # Install Weblogic
 execute "Install Weblogic" do
-  command "java -jar #{Chef::Config[:file_cache_path]}/wls_121200.jar -silent -silent_xml #{Chef::Config[:file_cache_path]}/silent.xml -responseFile #{Chef::Config[:file_cache_path]}/weblogic_install.rsp -Djava.security.egd=file:/dev/./urandom"
+  command "java -jar #{Chef::Config[:file_cache_path]}/wls_121200.jar -silent -silent_xml=#{Chef::Config[:file_cache_path]}/silent.xml -responseFile #{Chef::Config[:file_cache_path]}/weblogic_install.rsp -Djava.security.egd=file:/dev/./urandom"
   user node['weblogic']['user']
   group node['weblogic']['group']
   creates node['weblogic']['wls_install_dir']


### PR DESCRIPTION
Is there a reason that we don't explicitly cite the silent.xml on the install command?
