### PR TITLE
Add attribute 'installer_additional_options' to pass additional installer options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['weblogic']['local_jvms']                              = []
 default['weblogic']['bea_bundled_jvms']                        = []
 default['weblogic']['installer_download']                      = 'http://www.example.com/wls_121200.jar'
 default['weblogic']['installer_checksum']                      = 'e6efe85f3aec005ce037bd740f512e23c136635c63e20e02589ee0d0c50c065c'
+default['weblogic']['installer_additional_options']            = '' # Pass additional options to weblogic installer here. Available options at: http://docs.oracle.com/middleware/1212/core/OUIRF/silent.htm#OUIRF334
 default['weblogic']['install_type']                            = 'WebLogic Server'
 default['oui']['inventory_loc']                                = '/home/oracle/orainventory'
 default['oui']['install_group']                                = 'oracle'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,7 +63,7 @@ end
 
 # Install Weblogic
 execute "Install Weblogic" do
-  command "java -jar #{Chef::Config[:file_cache_path]}/wls_121200.jar -silent -silent_xml=#{Chef::Config[:file_cache_path]}/silent.xml -responseFile #{Chef::Config[:file_cache_path]}/weblogic_install.rsp -Djava.security.egd=file:/dev/./urandom"
+  command "java -jar #{Chef::Config[:file_cache_path]}/wls_121200.jar -silent -silent_xml=#{Chef::Config[:file_cache_path]}/silent.xml -responseFile #{Chef::Config[:file_cache_path]}/weblogic_install.rsp -Djava.security.egd=file:/dev/./urandom #{node['weblogic']['installer_additional_options']}"
   user node['weblogic']['user']
   group node['weblogic']['group']
   creates node['weblogic']['wls_install_dir']


### PR DESCRIPTION
Sometimes you need to pass additional options to the weblogic installer (you can find available options here: http://docs.oracle.com/middleware/1212/core/OUIRF/silent.htm#OUIRF334), so I added an attribute to make this possible.